### PR TITLE
Added additional fields, limit memo length, fix since_date parameter, added option to redistribute taxes

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -62,8 +62,14 @@ This script will:
 1. Load the previously saved JSON files
 2. Match YNAB transactions with Amazon orders based on the total amount
 3. Create detailed subtransactions for each item in the matched Amazon orders
-4. Preview the updates before applying them
-5. After your confirmation, update the transactions in YNAB
+4. Redistribute the "Sales Tax" line item across other items if necessary
+5. Preview the updates before applying them
+6. After your confirmation, update the transactions in YNAB
+
+If you'd like to keep "Sales Tax" as a separate line item:
+```bash
+python update_ynab.py --preserve-sales-tax-line
+```
 
 ### Handling Mismatches
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-amazon-orders==4.0.9
+amazon-orders==4.0.10
 amazoncaptcha==0.5.11
 beautifulsoup4==4.13.3
 certifi==2025.1.31

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -103,7 +103,7 @@ transactions = ynab_client.get_transactions(env_values.get("YNAB_BUDGET_ID"), yn
 amazon_transactions = []
 if 'data' in transactions and 'transactions' in transactions['data']:
     for transaction in transactions['data']['transactions']:
-        if transaction.get('payee_name') == args.payee_name:
+        if transaction.get('payee_name', '').lower().startswith(args.payee_name.lower()):
             amazon_transactions.append(transaction)
             print(f"Date: {transaction['date']}, Amount: ${abs(transaction['amount'])/1000:.2f}, Payee: {transaction['payee_name']}")
 

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -100,7 +100,7 @@ transactions = ynab_client.get_transactions(env_values.get("YNAB_BUDGET_ID"), yn
 amazon_transactions = []
 if 'data' in transactions and 'transactions' in transactions['data']:
     for transaction in transactions['data']['transactions']:
-        if transaction.get('payee_name', '').lower().startswith(args.payee_name.lower()):
+        if transaction.get('payee_name', '').lower() == args.payee_name.lower():
             amazon_transactions.append(transaction)
             print(f"Date: {transaction['date']}, Amount: ${abs(transaction['amount'])/1000:.2f}, Payee: {transaction['payee_name']}")
 

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -89,12 +89,15 @@ with open('amazon_orders.json', 'w') as f:
 # Initialize YNAB client with API key from .env
 ynab_client = YNAB(env_values.get("YNAB_API_KEY"))
 
-# Get today's date in ISO format
-ynab_date = args.ynab_date
+# Use provided date or fallback to today
+if args.ynab_date:
+    ynab_date = datetime.strptime(args.ynab_date, '%Y-%m-%d').date()
+else:
+    ynab_date = datetime.today().date()
 
 print(f"Fetching YNAB transactions from {ynab_date}...")
 # Get transactions using budget ID from .env
-transactions = ynab_client.get_transactions(env_values.get("YNAB_BUDGET_ID"))
+transactions = ynab_client.get_transactions(env_values.get("YNAB_BUDGET_ID"), ynab_date)
 
 # Filter and store Amazon transactions
 amazon_transactions = []

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -71,6 +71,12 @@ for order in orders:
         "shipping_total": order.shipping_total,
         "free_shipping": order.free_shipping,
         "refund_total": order.refund_total,
+        "reward_points": order.reward_points,
+        "promotion_applied": order.promotion_applied,
+        "multibuy_discount": order.multibuy_discount,
+        "amazon_discount": order.amazon_discount,
+        "gift_card": order.gift_card,
+        "gift_wrap": order.gift_wrap,        
         "items": items_data
     })
 

--- a/src/get_data.py
+++ b/src/get_data.py
@@ -89,11 +89,8 @@ with open('amazon_orders.json', 'w') as f:
 # Initialize YNAB client with API key from .env
 ynab_client = YNAB(env_values.get("YNAB_API_KEY"))
 
-# Use provided date or fallback to today
-if args.ynab_date:
-    ynab_date = datetime.strptime(args.ynab_date, '%Y-%m-%d').date()
-else:
-    ynab_date = datetime.today().date()
+# Get today's date in ISO format
+ynab_date = args.ynab_date
 
 print(f"Fetching YNAB transactions from {ynab_date}...")
 # Get transactions using budget ID from .env

--- a/src/update_ynab.py
+++ b/src/update_ynab.py
@@ -59,17 +59,7 @@ def find_matching_amazon_order(amazon_orders, ynab_transaction):
     ]
     
     if not matching_orders:
-
-        # Check if this matches a refund
-        if (ynab_amount > 0) :
-            matching_orders = [
-                order for order in amazon_orders 
-                if order['refund_total'] is not None and 
-                    abs(float(order['refund_total']) - abs(ynab_dollars)) < 0.01
-            ]
-
-        if not matching_orders:
-            return None
+        return None
 
     # Return the order with the closest date
     return min(

--- a/src/update_ynab.py
+++ b/src/update_ynab.py
@@ -377,8 +377,8 @@ def main():
     logger.info("Starting YNAB Amazon transaction update process")
     
     # Load command line arguments
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--redistribute-sales-tax', action='store_true', help='Redistribute sales tax across items')
+    parser = argparse.ArgumentParser(description='Update YNAB orders with details from Amazon transactions')
+    parser.add_argument('--preserve-sales-tax-line', action='store_true', help='Keep sales tax a separate item')
     args = parser.parse_args()
 
     # Load data from JSON files
@@ -517,7 +517,7 @@ def main():
             budget_id = env_values.get("YNAB_BUDGET_ID")
             logger.info(f"Using YNAB Budget ID: {budget_id}")
 
-            if args.redistribute_sales_tax:
+            if not args.preserve_sales_tax_line:
                 payload = redistribute_sales_tax(payload)
 
             status_code, response = ynab_client.patch_transactions(budget_id, payload)

--- a/src/update_ynab.py
+++ b/src/update_ynab.py
@@ -55,7 +55,8 @@ def find_matching_amazon_order(amazon_orders, ynab_amount):
     
     return matching_orders[0] if matching_orders else None
 
-def create_subtransactions(items, estimated_tax=None, order_total=None, ynab_amount=None, coupon_savings=None, subscription_discount=None, shipping_total=None, free_shipping=None):
+def create_subtransactions(items, estimated_tax=None, order_total=None, ynab_amount=None, coupon_savings=None, subscription_discount=None, shipping_total=None,
+                           free_shipping=None, reward_points=None, promotion_applied=None, multibuy_discount=None, amazon_discount=None, gift_card=None, gift_wrap=None):
     subtransactions = []
     items_with_no_price = []
     subtotal = 0
@@ -146,6 +147,67 @@ def create_subtransactions(items, estimated_tax=None, order_total=None, ynab_amo
             "memo": "Sales Tax"
         })
     
+    # Add gift wrap as a separate subtransaction if it exists
+    if gift_wrap and estimated_tax != 'None':
+        gift_wrap = int(round(float(gift_wrap) * -1000))  # Round before converting to int
+        subtotal += gift_wrap
+        subtransactions.append({
+            "amount": gift_wrap,
+            "payee_name": "Amazon",
+            "memo": "Gift Wrap"
+        })
+
+    # Add reward points if present (as negative amount)
+    if reward_points and reward_points != 'None' and float(reward_points) != 0:
+        reward_amount = int(round(float(reward_points) * -1000))  # Negative amount to represent discount
+        subtotal += reward_amount
+        subtransactions.append({
+            "amount": reward_amount,
+            "payee_name": "Amazon",
+            "memo": "Reward Points Used"
+        })
+
+    # Add promotion discount if present (as negative amount)
+    if promotion_applied and promotion_applied != 'None' and float(promotion_applied) != 0:
+        promo_amount = int(round(float(promotion_applied) * -1000))  # Negative amount for discount
+        subtotal += promo_amount
+        subtransactions.append({
+            "amount": promo_amount,
+            "payee_name": "Amazon",
+            "memo": "Promotion Applied"
+        })
+
+
+    # Add multibuy discount if present (as negative amount)
+    if multibuy_discount and multibuy_discount != 'None' and float(multibuy_discount) != 0:
+        promo_amount = int(round(float(multibuy_discount) * -1000))  # Negative amount for discount
+        subtotal += promo_amount
+        subtransactions.append({
+            "amount": promo_amount,
+            "payee_name": "Amazon",
+            "memo": "Multibuy Discount"
+        })
+
+    # Add amazon discount if present (as negative amount)
+    if amazon_discount and amazon_discount != 'None' and float(amazon_discount) != 0:
+        promo_amount = int(round(float(amazon_discount) * -1000))  # Negative amount for discount
+        subtotal += promo_amount
+        subtransactions.append({
+            "amount": promo_amount,
+            "payee_name": "Amazon",
+            "memo": "Amazon Discount"
+        })
+
+    # Add gift card if present (as negative amount)
+    if gift_card and gift_card != 'None' and float(gift_card) != 0:
+        promo_amount = int(round(float(gift_card) * -1000))  # Negative amount for discount
+        subtotal += promo_amount
+        subtransactions.append({
+            "amount": promo_amount,
+            "payee_name": "Amazon",
+            "memo": "Gift Card"
+        })
+
     # If we have the YNAB amount, adjust the subtransactions to match it exactly
     if ynab_amount and subtransactions:
         difference = ynab_amount - subtotal
@@ -330,7 +392,13 @@ def main():
                 matching_order.get('coupon_savings'),
                 matching_order.get('subscription_discount'),
                 matching_order.get('shipping_total'),
-                matching_order.get('free_shipping')
+                matching_order.get('free_shipping'),
+                matching_order.get('reward_points'),
+                matching_order.get('promotion_applied'),
+                matching_order.get('multibuy_discount'),
+                matching_order.get('amazon_discount'),
+                matching_order.get('gift_card'),
+                matching_order.get('gift_wrap')
             )
             if no_price_items:
                 orders_with_no_price_items[matching_order['order_details_link']] = no_price_items


### PR DESCRIPTION
- Added handling for `reward_points`, `promotion_applied`, `multibuy_discount`, `amazon_discount`, `gift_card`, `gift_wrap`.
- Upped `amazon-orders` to 4.0.10
- Fix issue where `since_date` parameter of `ynab_client.get_transactions` was always `None` due to missing function argument
- Add optional CLI flag to redistribute sales tax across subtransactions